### PR TITLE
Update readme and change URL for API to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Steamspy API client for PHP (http://steamspy.com/api.php)
 
 ## Installing
 ```bash
-composer require inside/steamspy-api
+composer require inside/steamspy-api-client
 ```
 
 ## Usage

--- a/src/Steamspy.php
+++ b/src/Steamspy.php
@@ -21,7 +21,7 @@ class Steamspy
     /**
      * API service URL
      */
-    const URL = 'http://steamspy.com/api.php';
+    const URL = 'https://steamspy.com/api.php';
 
     /**
      * Default poll rate to API


### PR DESCRIPTION
The readme was referencing the wrong Composer package, and the URL for the SteamSpy API needs to be https to avoid a curl error.